### PR TITLE
fix(csvHeader): headers with custom separator.

### DIFF
--- a/lib/csv-express.js
+++ b/lib/csv-express.js
@@ -83,7 +83,7 @@ res.csv = function(data, csvHeaders, headers, status) {
         header.push(prop);
       }
     }
-    body += header + '\r\n';
+    body += header.join(exports.separator) + '\r\n';
   }
 
   data.forEach(function(item) {


### PR DESCRIPTION
This fixes problems when a custom separator is set with headers.
