### PR TITLE
stricter parseFloat to handle hexadecimal numbers/strings

### DIFF
--- a/lib/csv-express.js
+++ b/lib/csv-express.js
@@ -17,6 +17,18 @@ exports.separator = ',';
 exports.preventCast = false;
 exports.ignoreNullOrUndefined = true;
 
+/**
+ * Stricter parseFloat to support hexadecimal strings from
+ * https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/parseFloat#A_stricter_parse_function
+ * @param {Mixed} value
+ */
+function filterFloat(value) {
+  if (/^(\-|\+)?([0-9]+(\.[0-9]+)?|Infinity)$/.test(value)) {
+    return Number(value);
+  }
+  return NaN;
+}
+
 /*
  * Escape CSV field
  *
@@ -32,7 +44,7 @@ function escape(field) {
   if (exports.preventCast) {
     return '="' + String(field).replace(/\"/g, '""') + '"';
   }
-  if (!isNaN(parseFloat(field)) && isFinite(field)) {
+  if (!isNaN(filterFloat(field)) && isFinite(field)) {
     return parseFloat(field);
   }
   return '"' + String(field).replace(/\"/g, '""') + '"';

--- a/test/2/index.js
+++ b/test/2/index.js
@@ -23,6 +23,12 @@ app.get('/test/3', function(req, res) {
   ]);
 });
 
+app.get('/test/hexadecimal', function(req, res) {
+  res.csv([
+    ['0x0bea5f7a45740a05a96099e4f9b4a732dfe006', 'b']
+  ])
+})
+
 app.get('/test/custom-headers', function(req, res) {
   res.csv([
     [ 'a', 'b', 'c' ]
@@ -136,6 +142,15 @@ describe('res.csv()', function() {
       .end(function(error, res) {
         csv.ignoreNullOrUndefined = prevOption;
         res.text.should.equal('"a","b","undefined"\r\n');
+        done();
+      });
+  });
+
+  it('should response correct hexadecimal', function(done) {
+    request
+      .get('http://127.0.0.1:8383/test/hexadecimal')
+      .end(function(error, res) {
+        res.text.should.equal('"0x0bea5f7a45740a05a96099e4f9b4a732dfe006","b"\r\n');
         done();
       });
   });

--- a/test/3+/index.js
+++ b/test/3+/index.js
@@ -23,6 +23,12 @@ app.get('/test/3', function(req, res) {
   ]);
 });
 
+app.get('/test/hexadecimal', function(req, res) {
+  res.csv([
+    ['0x0bea5f7a45740a05a96099e4f9b4a732dfe006', 'b']
+  ])
+})
+
 app.get('/test/custom-headers', function(req, res) {
   res.csv([
     [ 'a', 'b', 'c' ]
@@ -139,6 +145,15 @@ describe('res.csv()', function() {
       .end(function(error, res) {
         csv.ignoreNullOrUndefined = prevOption;
         res.text.should.equal('"a","b","undefined"\r\n');
+        done();
+      });
+  });
+
+  it('should response correct hexadecimal', function(done) {
+    request
+      .get('http://127.0.0.1:8383/test/hexadecimal')
+      .end(function(error, res) {
+        res.text.should.equal('"0x0bea5f7a45740a05a96099e4f9b4a732dfe006","b"\r\n');
         done();
       });
   });


### PR DESCRIPTION
My hex parsing was resulting into `0`,  it's the expected result for hexadecimal strings.

https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/parseFloat#A_stricter_parse_function